### PR TITLE
add missing Google library, update gradle and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A RecyclerView that is powered by Realm
 
-### Latest 1.7 is built with Realm 6.0.2
+### Latest 1.7.1 is built with Realm 6.0.2
 
 A powerful ```RecyclerView``` wrapper for working with ```Realm``` as your datastore. It supports the following features out of the box:
 
@@ -8,7 +8,7 @@ A powerful ```RecyclerView``` wrapper for working with ```Realm``` as your datas
 * Empty state
 * Pull-to-refresh (backed by SwipeRefreshLayout)
 * Infinite scrolling (callback for more data fetching)
-* Section headers (backed by SuperSLiM) (TODO)
+
 
 ##How To Include It:
 
@@ -23,7 +23,7 @@ A powerful ```RecyclerView``` wrapper for working with ```Realm``` as your datas
 
 ```
 	dependencies {
-	        compile 'com.github.m2f.realm-recyclerview:library:1.7'
+	        implementation 'com.github.m2f.realm-recyclerview:library:1.7.1'
 	}
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,14 +6,14 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.3'
         classpath "io.realm:realm-gradle-plugin:6.0.2"
     }
 }
 
 project.ext.minSdk = 19
 project.ext.compileSdk = 29
-project.ext.buildTools = "29.0.2"
+project.ext.buildTools = "29.0.3"
 
 allprojects {
     repositories {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -28,7 +28,8 @@ android {
 }
 
 dependencies {
-    api "com.google.android.material:material:1.0.0"
+    api "com.google.android.material:material:1.1.0"
+    api 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
     api "androidx.palette:palette:1.0.0"
     api "androidx.recyclerview:recyclerview:1.1.0"
     api 'com.tonicartos:superslim:0.4.13'


### PR DESCRIPTION
I found on some devices, it needs the library spinner library or it will crash. 

Can you also create the 1.7.1 release, if you merge this?